### PR TITLE
(Feat) Autostart QBasic with latest LTS Ubuntu

### DIFF
--- a/QBASIC-IN-A-DOCKER/Dockerfile
+++ b/QBASIC-IN-A-DOCKER/Dockerfile
@@ -7,7 +7,7 @@ ENV QB64_BUILD=$QB64_BUILD
 ENV DEBIAN_FRONTEND noninteractive
 ENV USER root
 
-COPY http://www.qb64.net/release/official/$QB64_BUILD-$QB64_VERSION/windows/qb64-$QB64_VERSION-win.zip /
+ADD http://www.qb64.net/release/official/$QB64_BUILD-$QB64_VERSION/windows/qb64-$QB64_VERSION-win.zip /
 
 RUN apt-get update && apt-get install -y \
     wget unzip dosbox && \ 

--- a/QBASIC-IN-A-DOCKER/Dockerfile
+++ b/QBASIC-IN-A-DOCKER/Dockerfile
@@ -12,3 +12,5 @@ COPY http://www.qb64.net/release/official/$QB64_BUILD-$QB64_VERSION/windows/qb64
 RUN apt-get update && apt-get install -y \
     wget unzip dosbox && \ 
     apt autoremove && rm -r /var/lib/apt/lists/*
+
+CMD ["nohup", "dosbox"]

--- a/QBASIC-IN-A-DOCKER/Dockerfile
+++ b/QBASIC-IN-A-DOCKER/Dockerfile
@@ -8,6 +8,7 @@ ENV DEBIAN_FRONTEND noninteractive
 ENV USER root
 
 ADD http://www.qb64.net/release/official/$QB64_BUILD-$QB64_VERSION/windows/qb64-$QB64_VERSION-win.zip /
+COPY dosbox.conf $HOME/.dosboxrc
 
 RUN apt-get update && apt-get install -y \
     wget unzip dosbox && \ 

--- a/QBASIC-IN-A-DOCKER/Dockerfile
+++ b/QBASIC-IN-A-DOCKER/Dockerfile
@@ -1,9 +1,14 @@
-FROM ubuntu:14.04
+FROM ubuntu:16.04
 MAINTAINER Jack Northrup jack@jacknorthrup.com
+ARG QB64_VERSION=1.1-20170120.51
+ENV QB64_VERSION=$QB64_VERSION
+ARG QB64_BUILD=2017_02_09__02_14_38
+ENV QB64_BUILD=$QB64_BUILD
 ENV DEBIAN_FRONTEND noninteractive
 ENV USER root
 
+COPY http://www.qb64.net/release/official/$QB64_BUILD-$QB64_VERSION/windows/qb64-$QB64_VERSION-win.zip /
+
 RUN apt-get update && apt-get install -y \
-    wget unzip dosbox \
-RUN apt autoremove && rm -r /var/lib/apt/lists/*
-RUN wget http://www.qb64.net/release/official/2017_02_09__02_14_38-1.1-20170120.51/windows/qb64-1.1-20170120.51-win.zip -O qb45.zip && unzip qb45.zip 
+    wget unzip dosbox && \ 
+    apt autoremove && rm -r /var/lib/apt/lists/*

--- a/QBASIC-IN-A-DOCKER/dosbox.conf
+++ b/QBASIC-IN-A-DOCKER/dosbox.conf
@@ -1,0 +1,4 @@
+[autoexec]
+mount c /qb45
+C:
+QB.EXE


### PR DESCRIPTION
* Parameterized image build
* Updated Ubuntu to latest LTS edition
* Removed erroneous `RUN` steps better performed by `ADD`
* Added autoexec that mounts and runs qbasic on startup
* Added startup for QBASIC as command so one can still enter the container